### PR TITLE
loosen share_plus version dependency 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   #
   # Packages by other parties:
   #
-  share_plus: ^6.3.1
+  share_plus: ">=6.3.1"
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Hi!
Would it be possible to loosen the share_plus version dependency please? I'm having compilation issues at the moment while latest version of share_plus is `10.1.3`:
```
Because no versions of web_browser match >0.7.4 and web_browser 0.7.4 depends on share_plus ^6.3.1, web_browser >=0.7.4 requires share_plus ^6.3.1.
```
Thanks!